### PR TITLE
Logic to separate windll check  for Win32 platforms only

### DIFF
--- a/frogtool.py
+++ b/frogtool.py
@@ -14,9 +14,11 @@ except ImportError:
     ImageDraw = None
     image_lib_avail = False
 
-import ctypes
-if ctypes.windll:
-    ctypes.windll.kernel32.SetConsoleTitleW("frogtool")
+from sys import platform
+if platform == "win32":
+    import ctypes
+    if ctypes.windll:
+        ctypes.windll.kernel32.SetConsoleTitleW("frogtool")
 
 systems = {
     "ARCADE": ["mswb7.tax", "msdtc.nec", "mfpmp.bvs"],


### PR DESCRIPTION
This PR fixes this tool for linux (tested and coded on Android using termux) by wrapping the windll call in an if statwment to check for win32 platform.
